### PR TITLE
improvement: block non usdc transfers to autocctp accounts

### DIFF
--- a/e2e/clear_account_test.go
+++ b/e2e/clear_account_test.go
@@ -27,13 +27,15 @@ import (
 	"strconv"
 	"testing"
 
-	"autocctp.dev/client/cli"
-	"autocctp.dev/types"
-	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"autocctp.dev/client/cli"
+	"autocctp.dev/types"
 )
 
 // TestClearAccount_ToFallbackRecipient tests that an AutoCCTP account can be correctly cleared by

--- a/e2e/register_account_test.go
+++ b/e2e/register_account_test.go
@@ -27,16 +27,18 @@ import (
 	"strconv"
 	"testing"
 
-	"autocctp.dev/client/cli"
-	"autocctp.dev/types"
-	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
-	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
 	"github.com/strangelove-ventures/interchaintest/v8/ibc"
 	"github.com/stretchr/testify/require"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	transfertypes "github.com/cosmos/ibc-go/v8/modules/apps/transfer/types"
+	clienttypes "github.com/cosmos/ibc-go/v8/modules/core/02-client/types"
+
+	"autocctp.dev/client/cli"
+	"autocctp.dev/types"
 )
 
 // TestRegisterAccount tests the registration of a new AutoCCTP account and the associated

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -25,12 +25,8 @@ import (
 	"fmt"
 	"testing"
 
-	"autocctp.dev/utils"
-	"cosmossdk.io/math"
 	cctptypes "github.com/circlefin/noble-cctp/x/cctp/types"
 	fiattokenfactorytypes "github.com/circlefin/noble-fiattokenfactory/x/fiattokenfactory/types"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
@@ -38,6 +34,12 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+
+	"cosmossdk.io/math"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
+
+	"autocctp.dev/utils"
 )
 
 var (

--- a/e2e/setup.go
+++ b/e2e/setup.go
@@ -25,8 +25,12 @@ import (
 	"fmt"
 	"testing"
 
+	"autocctp.dev/utils"
+	"cosmossdk.io/math"
 	cctptypes "github.com/circlefin/noble-cctp/x/cctp/types"
 	fiattokenfactorytypes "github.com/circlefin/noble-fiattokenfactory/x/fiattokenfactory/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
 	interchaintest "github.com/strangelove-ventures/interchaintest/v8"
 	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
@@ -34,12 +38,6 @@ import (
 	"github.com/strangelove-ventures/interchaintest/v8/testreporter"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
-
-	"cosmossdk.io/math"
-	sdk "github.com/cosmos/cosmos-sdk/types"
-	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
-
-	"autocctp.dev/utils"
 )
 
 var (
@@ -95,6 +93,7 @@ func NewAutoCCTPSuite(t *testing.T, isZeroFees bool, isIBC bool) (context.Contex
 				Version: "v8.5.1",
 				ChainConfig: ibc.ChainConfig{
 					ChainID: "ibc-1",
+					Denom:   "uibc",
 				},
 				NumValidators: &numValidators,
 				NumFullNodes:  &numFullNodes,

--- a/e2e/utils.go
+++ b/e2e/utils.go
@@ -26,14 +26,16 @@ import (
 	"encoding/json"
 	"testing"
 
-	"autocctp.dev/types"
 	cctptypes "github.com/circlefin/noble-cctp/x/cctp/types"
+	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
+	"github.com/stretchr/testify/require"
+
 	abci "github.com/cometbft/cometbft/abci/types"
 	coretypes "github.com/cometbft/cometbft/rpc/core/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/cosmos/gogoproto/jsonpb"
-	"github.com/strangelove-ventures/interchaintest/v8/chain/cosmos"
-	"github.com/stretchr/testify/require"
+
+	"autocctp.dev/types"
 )
 
 // Transactions

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -140,7 +140,7 @@ func (k *Keeper) SendRestrictionFn(ctx context.Context, _, toAddr sdk.AccAddress
 	}
 
 	if err = k.PendingTransfers.Set(ctx, account.Address, *account); err != nil {
-		k.logger.Error(`'while setting account for pending transfers in send restriction`,
+		k.logger.Error(`unable to set account for pending transfer`,
 			"account", account.Address,
 			"amount", coins.AmountOf(mintingDenom).String(),
 			"error", err,

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -147,7 +147,7 @@ func (k *Keeper) SendRestrictionFn(ctx context.Context, _, toAddr sdk.AccAddress
 		)
 	}
 
-	return toAddr, err
+	return toAddr, nil
 }
 
 // registerAccount handles the AutoCCTP account registration given certain properties.

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -139,8 +139,13 @@ func (k *Keeper) SendRestrictionFn(ctx context.Context, _, toAddr sdk.AccAddress
 		return toAddr, fmt.Errorf("autocctp accounts can only receive %s coins", mintingDenom)
 	}
 
-	// TODO: do we want to error here or allow the transfer in any case?
-	err = k.PendingTransfers.Set(ctx, account.Address, *account)
+	if err = k.PendingTransfers.Set(ctx, account.Address, *account); err != nil {
+		k.logger.Error(`'while setting account for pending transfers in send restriction`,
+			"account", account.Address,
+			"amount", coins.AmountOf(mintingDenom).String(),
+			"error", err,
+		)
+	}
 
 	return toAddr, err
 }

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -135,9 +135,12 @@ func (k *Keeper) SendRestrictionFn(ctx context.Context, _, toAddr sdk.AccAddress
 	}
 
 	mintingDenom := k.ftfKeeper.GetMintingDenom(ctx).Denom
-	if coins.AmountOf(mintingDenom).IsPositive() {
-		err = k.PendingTransfers.Set(ctx, account.Address, *account)
+	if len(coins) != 1 || !coins.AmountOf(mintingDenom).IsPositive() {
+		return toAddr, fmt.Errorf("autocctp accounts can only receive %s coins", mintingDenom)
 	}
+
+	// TODO: do we want to error here or allow the transfer in any case?
+	err = k.PendingTransfers.Set(ctx, account.Address, *account)
 
 	return toAddr, err
 }

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -23,9 +23,8 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/require"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 
 	"autocctp.dev/types"
 	"autocctp.dev/utils"
@@ -167,7 +166,7 @@ func TestSendRestrictionFn(t *testing.T) {
 			errContains:        "autocctp accounts can only receive",
 		},
 		{
-			name: "valid when coins cointains only minting denom",
+			name: "valid when coins contains only minting denom",
 			setup: func(ak *mocks.AccountKeeper) {
 				ak.Accounts[acc.GetAddress().String()] = &acc
 			},

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -23,8 +23,9 @@ package keeper_test
 import (
 	"testing"
 
-	sdk "github.com/cosmos/cosmos-sdk/types"
 	"github.com/stretchr/testify/require"
+
+	sdk "github.com/cosmos/cosmos-sdk/types"
 
 	"autocctp.dev/types"
 	"autocctp.dev/utils"

--- a/keeper/keeper_test.go
+++ b/keeper/keeper_test.go
@@ -23,10 +23,8 @@ package keeper_test
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"github.com/stretchr/testify/require"
 
 	"autocctp.dev/types"
 	"autocctp.dev/utils"
@@ -112,71 +110,97 @@ func TestValidateAccountProperties(t *testing.T) {
 }
 
 func TestSendRestrictionFn(t *testing.T) {
-	// ARRANGE
-	mocks, k, ctx := mocks.AutoCCTPKeeper(t)
-	ak := mocks.AccountKeeper
-
 	acc := utils.DummyAccountTest(false)
 
-	// ACT
-	toAddr, err := k.SendRestrictionFn(ctx, sdk.AccAddress{}, acc.GetAddress(), sdk.Coins{})
+	testCases := []struct {
+		name               string
+		setup              func(*mocks.AccountKeeper)
+		coins              sdk.Coins
+		expPendingTransfer bool
+		errContains        string
+	}{
+		{
+			name:               "valid when the account does not exist",
+			setup:              func(_ *mocks.AccountKeeper) {},
+			coins:              sdk.Coins{},
+			expPendingTransfer: false,
+			errContains:        "",
+		},
+		{
+			name: "valid when the account is base account",
+			setup: func(ak *mocks.AccountKeeper) {
+				ak.Accounts[acc.GetAddress().String()] = acc.BaseAccount
+			},
+			coins:              sdk.Coins{},
+			expPendingTransfer: false,
+			errContains:        "",
+		},
+		{
+			name: "invalid when coins is empty",
+			setup: func(ak *mocks.AccountKeeper) {
+				ak.Accounts[acc.GetAddress().String()] = &acc
+			},
+			coins:              sdk.Coins{},
+			expPendingTransfer: false,
+			errContains:        "autocctp accounts can only receive",
+		},
+		{
+			name: "invalid when coin is not minting denom",
+			setup: func(ak *mocks.AccountKeeper) {
+				ak.Accounts[acc.GetAddress().String()] = &acc
+			},
+			coins:              sdk.NewCoins(sdk.NewInt64Coin("unobl", 1)),
+			expPendingTransfer: false,
+			errContains:        "autocctp accounts can only receive",
+		},
+		{
+			name: "invalid when coins contains more than one coin",
+			setup: func(ak *mocks.AccountKeeper) {
+				ak.Accounts[acc.GetAddress().String()] = &acc
+			},
+			coins: sdk.NewCoins(
+				sdk.NewInt64Coin("unobl", 1),
+				sdk.NewInt64Coin("uusdc", 1),
+			),
+			expPendingTransfer: false,
+			errContains:        "autocctp accounts can only receive",
+		},
+		{
+			name: "valid when coins cointains only minting denom",
+			setup: func(ak *mocks.AccountKeeper) {
+				ak.Accounts[acc.GetAddress().String()] = &acc
+			},
+			coins:              sdk.NewCoins(sdk.NewInt64Coin("uusdc", 1)),
+			expPendingTransfer: true,
+			errContains:        "",
+		},
+	}
 
-	// ASSERT
-	assert.NoError(t, err)
-	assert.Equal(t, acc.GetAddress(), toAddr, "expected the returned address unaltered")
+	for _, tC := range testCases {
+		t.Run(tC.name, func(t *testing.T) {
+			// ARRANGE
+			mocks, k, ctx := mocks.AutoCCTPKeeper(t)
+			ak := mocks.AccountKeeper
 
-	_, err = k.PendingTransfers.Get(ctx, acc.GetAddress().String())
-	assert.Error(t, err, "expected no registered pending transfers when receiver is not a stored account")
+			tC.setup(ak)
 
-	// ARRANGE
-	ak.Accounts[acc.GetAddress().String()] = acc.BaseAccount
+			// ACT
+			toAddr, err := k.SendRestrictionFn(ctx, sdk.AccAddress{}, acc.GetAddress(), tC.coins)
+			require.Equal(t, acc.GetAddress(), toAddr, "expected the returned address unaltered")
 
-	// ACT
-	toAddr, err = k.SendRestrictionFn(ctx, sdk.AccAddress{}, acc.GetAddress(), sdk.Coins{})
+			if tC.errContains == "" {
+				require.NoError(t, err, "expected no error calling the send restriction function")
+			} else {
+				require.Error(t, err, "expected an error calling the send restriction function")
+				require.ErrorContains(t, err, tC.errContains, "expected a different error")
+			}
 
-	// ASSERT
-	assert.NoError(t, err)
-	assert.Equal(t, acc.GetAddress(), toAddr, "expected the returned address unaltered")
-
-	_, err = k.PendingTransfers.Get(ctx, acc.GetAddress().String())
-	assert.Error(t, err, "expected no registered pending transfers when receiver is not autocctp account")
-
-	// ARRANGE
-	ak.Accounts[acc.GetAddress().String()] = &acc
-
-	// ACT: Call function with an nil account
-	toAddr, err = k.SendRestrictionFn(ctx, sdk.AccAddress{}, acc.GetAddress(), sdk.Coins{})
-
-	// ASSERT
-	assert.NoError(t, err)
-	assert.Equal(t, acc.GetAddress(), toAddr, "expected the returned address unaltered")
-
-	_, err = k.PendingTransfers.Get(ctx, acc.GetAddress().String())
-	assert.Error(t, err, "expected no registered pending transfers when coins is empty")
-
-	// ARRANGE
-	coins := sdk.NewCoins(sdk.NewInt64Coin("unobl", 1))
-
-	// ACT
-	toAddr, err = k.SendRestrictionFn(ctx, sdk.AccAddress{}, acc.GetAddress(), coins)
-
-	// ASSERT
-	assert.NoError(t, err)
-	assert.Equal(t, acc.GetAddress(), toAddr, "expected the returned address unaltered")
-
-	_, err = k.PendingTransfers.Get(ctx, acc.GetAddress().String())
-	assert.Error(t, err, "expected no registered pending transfers when coins does not contain minting denom")
-
-	// ARRANGE
-	coins = coins.Add(sdk.NewInt64Coin("uusdc", 1))
-
-	// ACT
-	toAddr, err = k.SendRestrictionFn(ctx, sdk.AccAddress{}, acc.GetAddress(), coins)
-
-	// ASSERT
-	assert.NoError(t, err)
-	assert.Equal(t, acc.GetAddress(), toAddr, "expected the returned address unaltered")
-
-	_, err = k.PendingTransfers.Get(ctx, acc.GetAddress().String())
-	assert.NoError(t, err, "expected one pending transfer associated with the address")
+			_, err = k.PendingTransfers.Get(ctx, acc.GetAddress().String())
+			if tC.expPendingTransfer {
+				require.NoError(t, err, "expected no error retrieving pending transfer")
+			} else {
+				require.Error(t, err, "expected no registered pending transfer")
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Description

- Return an error in send restriction function when non USDC funds are transferred to autocctp accounts.
- Add unit tests.
- Add IBC tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Revised transfer validation so that AutoCCTP accounts only accept a single, valid token. Transactions with multiple tokens or unsupported denominations are now properly rejected with clear error messages.

- **New Features**
  - Introduced support for a new token denomination ("uibc") in the blockchain configuration to enhance token handling for transfers.
  - Added a new test function to verify the handling of unsupported token transfers to AutoCCTP accounts, improving the testing suite's coverage.
  - Restructured existing tests for better clarity and maintainability using a table-driven approach.

- **Chores**
  - Reorganized import statements in test files for improved code structure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->