### PR TITLE
improvement: always add custom pub key

### DIFF
--- a/client/cli/tx.go
+++ b/client/cli/tx.go
@@ -23,11 +23,12 @@ package cli
 import (
 	"fmt"
 
+	"github.com/spf13/cobra"
+
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
-	"github.com/spf13/cobra"
 
 	"autocctp.dev/types"
 )

--- a/client/cli/tx.go
+++ b/client/cli/tx.go
@@ -23,12 +23,11 @@ package cli
 import (
 	"fmt"
 
-	"github.com/spf13/cobra"
-
 	"github.com/cosmos/cosmos-sdk/client"
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	signingtypes "github.com/cosmos/cosmos-sdk/types/tx/signing"
+	"github.com/spf13/cobra"
 
 	"autocctp.dev/types"
 )
@@ -128,11 +127,12 @@ func TxRegisterAccountSignerlessly() *cobra.Command {
 			// Create an empty signature with the custom PubKey to allow non existent
 			// account to send `MsgRegisterAccountSignerlessly` messages.
 			err = builder.SetSignatures(signingtypes.SignatureV2{
-				PubKey: &types.PubKey{Key: address},
+				PubKey: &types.PubKey{Key: address.Bytes()},
 				Data: &signingtypes.SingleSignatureData{
 					SignMode:  signingtypes.SignMode_SIGN_MODE_DIRECT,
 					Signature: []byte(""),
 				},
+				Sequence: 0,
 			})
 			if err != nil {
 				return nil

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -189,7 +189,7 @@ func (k Keeper) registerAccount(ctx context.Context, accountProperties types.Acc
 	}
 
 	base := k.accountKeeper.NewAccountWithAddress(ctx, address)
-	baseAccount := authtypes.NewBaseAccount(base.GetAddress(), base.GetPubKey(), base.GetAccountNumber(), base.GetSequence())
+	baseAccount := authtypes.NewBaseAccount(base.GetAddress(), &types.PubKey{Key: address.Bytes()}, base.GetAccountNumber(), base.GetSequence())
 
 	account := types.NewAccount(baseAccount, accountProperties)
 


### PR DESCRIPTION
This PR updates the generation of AutoCCTP accounts to always set the custom public key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Improved transaction signing by ensuring public key data is formatted consistently and by introducing sequence tracking.
	- Enhanced account registration with a revised key handling approach for better consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->