### PR TITLE
chore: allow vangen manual deployment

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "vangen.json"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced our deployment pipeline by adding a manual trigger option alongside automatic updates, offering greater operational flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->