### PR TITLE
chore: use `GOWORK=off` for build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ all: proto-all format lint license test-unit build
 
 build:
 	@echo "🤖 Building simd..."
-	@cd simapp && make build 1> /dev/null
+	@cd simapp && GOWORK=off make build 1> /dev/null
 	@echo "✅ Completed build!"
 
 ###############################################################################


### PR DESCRIPTION
## Description

This PR fixes a possible issue arising from the usage of `go.work`. 

When this file is present, even though every module has its own `go.mod`, at build time, all the `go.mod` are merged into one single list causing possible dependencies bleeding. This situation can arise when we have the tools module (not present here but will be added) or the e2e module that have dependencies with different requirements than the root `go.mod` or the `simapp` one. 

## Example

If we have package `github.com/something/x v1.0.0` in the simapp dependencies list  but the e2e module uses`github.com/something/x v1.0.9`, the latter will be used when building the binary. Even thought in the ideal world this should not happen, it is still better to prevent this issue and be sure that dependencies used during tests are the same used in production.

## Fix

By adding `GOWORK=off` in the build command, we ensure that the `go.work` is ignored and the E2E tests use the same binary we are going to use in production.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process to improve compatibility during application compilation. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->