### PR TITLE
fix: add correct sequence to signerless tx

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -210,8 +210,12 @@ To register a new AutoCCTP account for the same information of the previous
 example:
 
 ```sh
+./simapp/build/simd tx bank send validator noble1du3zaju8jjne4qa8m2n0tgg707khcvrm5h2stg 100000uusdc --from validator --home .autocctp --chain-id autocctp-1 --keyring-backend test
 ./simapp/build/simd tx autocctp register-account 0 0xaB537dC791355d986A4f7a9a53f3D8810fd870D1 noble1h8tqx833l3t2s45mwxjz29r85dcevy93wk63za --from validator --home .autocctp --chain-id autocctp-1 --keyring-backend test
 ```
+
+Doing the registration without first sending at least `10000uusdc` to the future
+AutoCCTP account will fail in the ante handler.
 
 To register the account signerlessly:
 

--- a/.github/README.md
+++ b/.github/README.md
@@ -210,18 +210,14 @@ To register a new AutoCCTP account for the same information of the previous
 example:
 
 ```sh
-./simapp/build/simd tx bank send validator noble1du3zaju8jjne4qa8m2n0tgg707khcvrm5h2stg 100000uusdc --from validator --home .autocctp --chain-id autocctp-1 --keyring-backend test
 ./simapp/build/simd tx autocctp register-account 0 0xaB537dC791355d986A4f7a9a53f3D8810fd870D1 noble1h8tqx833l3t2s45mwxjz29r85dcevy93wk63za --from validator --home .autocctp --chain-id autocctp-1 --keyring-backend test
 ```
 
-Doing the registration without first sending at least `10000uusdc` to the future
-AutoCCTP account will fail in the ante handler.
-
-To register the account signerlessly:
+To register the account signerlessly, the future AutoCCTP account has to be
+registered in the store and should have at least the minimum amount of $USDC
+required from the protocol.
 
 ```sh
+./simapp/build/simd tx bank send validator noble1du3zaju8jjne4qa8m2n0tgg707khcvrm5h2stg 100000uusdc --from validator --home .autocctp --chain-id autocctp-1 --keyring-backend test
 ./simapp/build/simd tx autocctp register-account-signerlessly 0 0xaB537dC791355d986A4f7a9a53f3D8810fd870D1 noble1h8tqx833l3t2s45mwxjz29r85dcevy93wk63za --from validator --home .autocctp --chain-id autocctp-1 --keyring-backend test
 ```
-
-For this transaction to work, the future AutoCCTP account has to be registered
-in the store and should have funds to pay for the tx fees.

--- a/ante.go
+++ b/ante.go
@@ -93,7 +93,7 @@ func (d SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 		mintToken := d.ftf.GetMintingDenom(ctx)
 		balance := d.bank.GetBalance(ctx, address, mintToken.Denom)
 		if balance.Amount.LT(types.GetMinimumTransferAmount()) {
-			return ctx, types.ErrInvalidAmount.Wrapf("must have at least %s%s", types.GetMinimumTransferAmount().String(), mintToken.Denom)
+			return ctx, types.ErrInvalidAccountBalance.Wrapf("must have at least %s%s", types.GetMinimumTransferAmount().String(), mintToken.Denom)
 		}
 
 		return next(ctx, tx, simulate)

--- a/ante.go
+++ b/ante.go
@@ -84,12 +84,16 @@ func (d SigVerificationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simulat
 
 		address := types.GenerateAddress(msg.GetAccountProperties())
 
+		if msg.Signer != address.String() {
+			return d.underlying.AnteHandle(ctx, tx, simulate, next)
+		}
+
 		// Check if the balance of the wannabe AutoCCTP account is not zero to prevent spam
 		// attacks of AutoCCTP accounts.
 		mintToken := d.ftf.GetMintingDenom(ctx)
 		balance := d.bank.GetBalance(ctx, address, mintToken.Denom)
-		if balance.Amount.LT(types.GetMinimumTransferAmount()) || msg.Signer != address.String() {
-			return d.underlying.AnteHandle(ctx, tx, simulate, next)
+		if balance.Amount.LT(types.GetMinimumTransferAmount()) {
+			return ctx, types.ErrInvalidAmount.Wrapf("future autocctp account must have at least %s%s in the balance", types.GetMinimumTransferAmount().String(), mintToken.Denom)
 		}
 
 		return next(ctx, tx, simulate)

--- a/client/cli/tx.go
+++ b/client/cli/tx.go
@@ -138,8 +138,8 @@ func TxRegisterAccountSignerlessly() *cobra.Command {
 			}
 
 			// Since the signerless transaction does not require the AutoCCTP account to be in
-			// the keychain, all time a signerless tx is sent, the sequence is always zero. By
-			// querying the account it is possible to use the correct sequence.
+			// the keychain, by default, the transaction sequence is always zero. By
+			// querying the account, it is possible to use the correct sequence.
 			sequence := uint64(0)
 			if err := clientCtx.AccountRetriever.EnsureExists(clientCtx, address); err == nil {
 				acc, err := clientCtx.AccountRetriever.GetAccount(clientCtx, address)

--- a/keeper/keeper.go
+++ b/keeper/keeper.go
@@ -169,7 +169,7 @@ func (k *Keeper) SendRestrictionFn(ctx context.Context, _, toAddr sdk.AccAddress
 	// intentionally not checking if the coins sent plus the current balance are higher
 	// than the minimum amount to transfer to always force the minimum amount.
 	if mintingDenomAmount.LT(types.GetMinimumTransferAmount()) || mintingDenomAmount.GT(maxTransferAmount) {
-		return toAddr, fmt.Errorf(
+		return toAddr, types.ErrInvalidAmount.Wrapf(
 			"transfer amount to autocctp account should be %s <= x <= %s",
 			types.GetMinimumTransferAmount().String(),
 			maxTransferAmount.String(),

--- a/types/errors.go
+++ b/types/errors.go
@@ -29,4 +29,5 @@ var (
 	ErrInvalidMintRecipient     = errors.Register(ModuleName, 3, "invalid mint recipient")
 	ErrInvalidFallbackRecipient = errors.Register(ModuleName, 4, "invalid fallback recipient")
 	ErrInvalidDestinationCaller = errors.Register(ModuleName, 5, "invalid destination caller")
+	ErrInvalidAmount            = errors.Register(ModuleName, 6, "invalid autocctp account balance")
 )

--- a/types/errors.go
+++ b/types/errors.go
@@ -29,6 +29,6 @@ var (
 	ErrInvalidMintRecipient     = errors.Register(ModuleName, 3, "invalid mint recipient")
 	ErrInvalidFallbackRecipient = errors.Register(ModuleName, 4, "invalid fallback recipient")
 	ErrInvalidDestinationCaller = errors.Register(ModuleName, 5, "invalid destination caller")
-	ErrInvalidTransferAmount    = errors.Register(ModuleName, 6, "invalid autocctp transfer amount")
-	ErrInvalidAmount            = errors.Register(ModuleName, 7, "invalid autocctp account balance")
+	ErrInvalidTransferAmount    = errors.Register(ModuleName, 6, "invalid transfer amount")
+	ErrInvalidAccountBalance    = errors.Register(ModuleName, 7, "invalid account balance")
 )


### PR DESCRIPTION
## Description

- Add the correct sequence to the signerless tx to generate a unique tx hash.
- Register SDK error to return the correct codespace in ante.
- Return the underlying ante only if the signer is not the AutoCCTP account address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated registration instructions to include a prerequisite step for funding new accounts and added a note about minimum balance requirements to prevent registration failures.

- **Bug Fixes**
  - Improved transaction construction to use the correct account sequence number for signerless registrations, enhancing reliability.
  - Enhanced error handling to explicitly notify users when account balances are insufficient during registration attempts.

- **New Features**
  - Introduced clearer error messaging for insufficient account balances during registration attempts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->